### PR TITLE
Add new test ContentFallbackWithOverlaySetToHideNonTranslatedAndTranslat...

### DIFF
--- a/Configuration/TypoScript/LanguageUid/3.ts
+++ b/Configuration/TypoScript/LanguageUid/3.ts
@@ -1,0 +1,3 @@
+config.sys_language_uid = 3
+config.language         = fr
+config.locale_all       = fr_FR.utf8

--- a/Tests/Functional/Fixtures/pages_language_overlay.xml
+++ b/Tests/Functional/Fixtures/pages_language_overlay.xml
@@ -16,4 +16,12 @@
 		<hidden>0</hidden>
 		<sys_language_uid>2</sys_language_uid>
 	</pages_language_overlay>
+	<pages_language_overlay>
+		<uid>3</uid>
+		<pid>1</pid>
+		<title>Root [French]</title>
+		<deleted>0</deleted>
+		<hidden>0</hidden>
+		<sys_language_uid>3</sys_language_uid>
+	</pages_language_overlay>
 </dataset>

--- a/Tests/Functional/Fixtures/sys_language.xml
+++ b/Tests/Functional/Fixtures/sys_language.xml
@@ -18,4 +18,13 @@
 		<flag>es</flag>
 		<static_lang_isocode>0</static_lang_isocode>
 	</sys_language>
+	<sys_language>
+		<uid>3</uid>
+		<pid>0</pid>
+		<tstamp>1422732070</tstamp>
+		<hidden>0</hidden>
+		<title>French</title>
+		<flag>fr</flag>
+		<static_lang_isocode>0</static_lang_isocode>
+	</sys_language>
 </dataset>

--- a/Tests/Functional/Fixtures/tx_extbaselanguagetests_domain_model_item.xml
+++ b/Tests/Functional/Fixtures/tx_extbaselanguagetests_domain_model_item.xml
@@ -52,4 +52,17 @@
 		<l18n_parent>0</l18n_parent>
 		<l18n_diffsource>a:3:{s:16:"sys_language_uid";N;s:6:"hidden";N;s:5:"title";N;}</l18n_diffsource>
 	</tx_extbaselanguagetests_domain_model_item>
+	<tx_extbaselanguagetests_domain_model_item>
+		<uid>5</uid>
+		<pid>1</pid>
+		<title>[FR] 1</title>
+		<tstamp>1422732862</tstamp>
+		<crdate>1422732862</crdate>
+		<deleted>0</deleted>
+		<hidden>1</hidden>
+		<t3_origuid>1</t3_origuid>
+		<sys_language_uid>3</sys_language_uid>
+		<l18n_parent>1</l18n_parent>
+		<l18n_diffsource>a:3:{s:16:"sys_language_uid";s:1:"0";s:6:"hidden";s:1:"0";s:5:"title";s:6:"Bucket";}</l18n_diffsource>
+	</tx_extbaselanguagetests_domain_model_item>
 </dataset>

--- a/Tests/Functional/LanguageModeTest.php
+++ b/Tests/Functional/LanguageModeTest.php
@@ -188,4 +188,40 @@ class LanguageModeTest extends AbstractTestCase {
 		 */
 		$this->assertCount(0, $queryResult);
 	}
+
+	/**
+	 * @test
+	 */
+	public function ContentFallbackWithOverlaySetToHideNonTranslatedAndTranslatedHiddenTest() {
+
+		/**
+		 * Test Setup
+		 */
+		$this->addTypoScriptToLoad('EXT:extbase_language_tests/Configuration/TypoScript/LanguageUid/3.ts');
+		$this->addTypoScriptToLoad('EXT:extbase_language_tests/Configuration/TypoScript/LanguageOverlay/HideNonTranslated.ts');
+		$this->addTypoScriptToLoad('EXT:extbase_language_tests/Configuration/TypoScript/LanguageMode/ContentFallback.ts');
+		$this->setUpFrontend();
+		$this->itemRepository = $this->objectManager->get(\SCHNITZLER\ExtbaseLanguageTests\Domain\Repository\ItemRepository::class);
+
+		$queryResult = $this->itemRepository->findAll();
+		$query = $queryResult->getQuery();
+
+
+		/*********************************************************************************************************************************/
+
+		/**
+		 * Check that language settings affect the query settings
+		 */
+		$this->assertEquals('hideNonTranslated', $query->getQuerySettings()->getLanguageOverlayMode());
+		$this->assertEquals(3, $query->getQuerySettings()->getLanguageUid());
+		$this->assertEquals('content_fallback', $query->getQuerySettings()->getLanguageMode());
+
+		/**
+		 * There should be 0 records because overlaying is enabled and
+		 * there is a page overlay for language 2 but only a hidden record with a
+		 * translation of language 3 exist.
+		 */
+		$this->assertCount(0, $queryResult);
+	}
+
 }


### PR DESCRIPTION
...edHiddenTest

Wenn es für einen Record einen übersetzten Eintrag gibt, dieser aber auf 'hidden' gesetzt ist, sollte kein Ergebnis zurückgegeben werden.
